### PR TITLE
Monkey-patch for jQuery 3.0

### DIFF
--- a/smoothSort.js
+++ b/smoothSort.js
@@ -117,7 +117,13 @@ License: MIT
       opt.scrollOffset.x = opt.scrollContainer.scrollLeft();
       opt.scrollOffset.y = opt.scrollContainer.scrollTop();
 
-      var containerOffset             = opt.scrollContainer.offset() || {top:0,left:0};
+      var containerOffset;
+      try {
+        containerOffset = opt.scrollContainer.offset() || { top: 0, left: 0 };
+      } catch (err) {
+        containerOffset = { top: 0, left: 0 };
+      }
+      
       opt.scrollContainerPosition.x   = containerOffset.left;
       opt.scrollContainerPosition.y   = containerOffset.top;
       opt.scrollContainerSize.w       = opt.scrollContainer.width();


### PR DESCRIPTION
This closes #1. Although there might be a better solution out there.

Using the [jQuery migrate tool](https://github.com/jquery/jquery-migrate), I got this error message:

https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryfnoffset-requires-an-element-connected-to-a-document